### PR TITLE
docs(README): fix link underlines under badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
 # Plus Ultra
 
-<a href="https://nixos.wiki/wiki/Flakes" target="_blank">
-	<img alt="Nix Flakes Ready" src="https://img.shields.io/static/v1?logo=nixos&logoColor=d8dee9&label=Nix%20Flakes&labelColor=5e81ac&message=Ready&color=d8dee9&style=for-the-badge">
-</a>
-<a href="https://github.com/snowfallorg/lib" target="_blank">
-	<img alt="Built With Snowfall" src="https://img.shields.io/static/v1?logoColor=d8dee9&label=Built%20With&labelColor=5e81ac&message=Snowfall&color=d8dee9&style=for-the-badge">
-</a>
-<a href="https://jakehamilton.github.io/config" target="_blank">
-	<img alt="Frost Documentation" src="https://img.shields.io/static/v1?logoColor=d8dee9&label=Frost&labelColor=5e81ac&message=Documentation&color=d8dee9&style=for-the-badge">
-</a>
+<a href="https://nixos.wiki/wiki/Flakes" target="_blank"><img alt="Nix Flakes Ready" src="https://img.shields.io/static/v1?logo=nixos&logoColor=d8dee9&label=Nix%20Flakes&labelColor=5e81ac&message=Ready&color=d8dee9&style=for-the-badge"></a>
+<a href="https://github.com/snowfallorg/lib" target="_blank"><img alt="Built With Snowfall" src="https://img.shields.io/static/v1?logoColor=d8dee9&label=Built%20With&labelColor=5e81ac&message=Snowfall&color=d8dee9&style=for-the-badge"></a>
+<a href="https://jakehamilton.github.io/config" target="_blank"><img alt="Frost Documentation" src="https://img.shields.io/static/v1?logoColor=d8dee9&label=Frost&labelColor=5e81ac&message=Documentation&color=d8dee9&style=for-the-badge"></a>
 
-<p>
-<!--
-	This paragraph is not empty, it contains an em space (UTF-8 8195) on the next line in order
-	to create a gap in the page.
--->
-  
-</p>
+&nbsp;
 
 > ✨ Go even farther beyond.
 


### PR DESCRIPTION
Removes whitespace around the HTML for the badges to remove the link underlines:

| Before | After |
| --- | --- |
| ![image](https://github.com/jakehamilton/config/assets/47499684/1bbad040-2140-4344-ae6f-39a2a5a10705) | ![image](https://github.com/jakehamilton/config/assets/47499684/27116122-a092-44eb-92d4-9873adcb319b) |

Also switches to using an `&nbsp;` for the empty space.